### PR TITLE
Use semantic version formatting for module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,11 +8,11 @@
   "dependencies": [
     {
       "name": "herculesteam-augeasproviders_core",
-      "version_requirement": ">= 2.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     },
     {
       "name": "herculesteam-augeasproviders_sysctl",
-      "version_requirement": ">= 2.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
When running `puppet module list --tree`, it reports this:
```
Warning: Non semantic version dependency 'herculesteam-augeasproviders_core' (v2.3.0):
  'deric-sysctl_conf' (v0.1.0) requires 'herculesteam-augeasproviders_core' (>= 2.0 < 3.0.0)
Warning: Non semantic version dependency 'herculesteam-augeasproviders_sysctl' (v2.2.1):
  'deric-sysctl_conf' (v0.1.0) requires 'herculesteam-augeasproviders_sysctl' (>= 2.0 < 3.0.0)
```

Changing the values to semver format fixes the problem.