### PR TITLE
Set hiera lookup_options to merge: hash

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,9 @@
 ---
+lookup_options:
+  sysctl_conf::values:
+    merge:
+      strategy: deep
+      merge_hash_arrays: true
+  sysctl_conf::entry:
+    merge:
+      strategy: hash


### PR DESCRIPTION
Having these set to merge by default makes overrides further down the chain much cleaner.  This way I can just override the `value` and leave the other attributes from below.